### PR TITLE
fix: info redirect link

### DIFF
--- a/frontend/libs/features/settings/src/pages/info/info.component.html
+++ b/frontend/libs/features/settings/src/pages/info/info.component.html
@@ -14,6 +14,7 @@
 
 <div class="bg-base-100 rounded-2xl shadow flex flex-col mt-4">
   <a
+    target="_blank"
     href="https://github.com/Job79/lectoraat-smart-energy"
     class="flex justify-between items-center w-full border-b border-base-200 px-5 py-4"
   >
@@ -22,6 +23,7 @@
   </a>
 
   <a
+    target="_blank"
     href="https://github.com/Job79/lectoraat-smart-energy/issues"
     class="flex justify-between items-center w-full border-b border-base-200 px-5 py-4"
   >


### PR DESCRIPTION
![5318F2DB-C128-4128-90EE-A0E8AA721175_4_5005_c](https://github.com/Job79/lectoraat-smart-energy/assets/117987244/1082ce0b-9a3c-4c27-a3ce-21a8c24a7569)

Target blank zou het moet fixen. De link in footer is target blank en die werkt wel. het is denk zoizo netter om nieuwe pagina te openen voor source code